### PR TITLE
feat: enhance changelog generation with debugging and improved git integration

### DIFF
--- a/bin/publisher.ts
+++ b/bin/publisher.ts
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 // packages/publisher/bin/publisher.ts
 import { Command } from "commander";
+import pkg from "../package.json";
+import { changelogCommand } from "../src/commands/changelog";
 import { initCommand } from "../src/commands/init";
+import { integrityCommand } from "../src/commands/integrity";
 import { releaseCommand } from "../src/commands/release";
 import { validateCommand } from "../src/commands/validate";
-import { changelogCommand } from "../src/commands/changelog";
-import { integrityCommand } from "../src/commands/integrity";
-import pkg from "../package.json";
 import workspacesCommand from "../src/commands/workspaces";
 
 const program = new Command();
@@ -19,13 +19,21 @@ program
     "--cwd <path>",
     "Working directory to run commands from",
     process.cwd(),
-  );
+  )
+  .option("--debug", "Enable debug logging", false);
 
-// Add middleware to handle cwd before any command execution
+// Add middleware to handle cwd and debug before any command execution
 program.hook("preAction", (thisCommand) => {
-  const options = thisCommand.opts<{ cwd: string }>();
+  const options = thisCommand.opts<{ cwd: string; debug: boolean }>();
+
+  // Handle cwd
   if (options.cwd) {
     process.chdir(options.cwd);
+  }
+
+  // Handle debug mode
+  if (options.debug) {
+    process.env.DEBUG = "true";
   }
 });
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lint": "eslint \"**/*.ts\"",
     "lint:fix": "eslint \"**/*.ts\" --fix",
     "format": "prettier --write \"src/**/*.ts\" \"bin/**/*.ts\"",
-    "release": "node ./dist/bin/publisher.js publish",
+    "release": "node ./dist/bin/publisher.js release",
     "dev": "DEBUG=true node --inspect -r ts-node/register bin/publisher.ts",
     "publisher": "ts-node bin/publisher.ts",
     "publisher:debug": "DEBUG=true node --inspect -r ts-node/register bin/publisher.ts release --no-git-check --cwd ../gitguard",

--- a/src/core/__tests__/changelog-conventional.test.ts
+++ b/src/core/__tests__/changelog-conventional.test.ts
@@ -15,12 +15,36 @@ jest.mock("fs", () => ({
     access: jest.fn(),
     stat: jest.fn(),
   },
+  statSync: jest.fn().mockReturnValue({
+    isFile: () => true,
+    isDirectory: () => true,
+  }),
 }));
 
 jest.mock("conventional-changelog", () => jest.fn());
+jest.mock("simple-git", () => {
+  return jest.fn().mockImplementation(() => ({
+    init: jest.fn(),
+    addConfig: jest.fn(),
+    checkIsRepo: jest.fn().mockResolvedValue(true),
+    status: jest.fn().mockResolvedValue({ current: "main" }),
+    branch: jest.fn().mockResolvedValue({ current: "main" }),
+    raw: jest.fn().mockResolvedValue(""),
+    log: jest.fn().mockResolvedValue({ all: [] }),
+    tags: jest.fn().mockResolvedValue({ all: [] }),
+    revparse: jest.fn().mockResolvedValue(""),
+    show: jest.fn().mockResolvedValue(""),
+    diff: jest.fn().mockResolvedValue(""),
+    fetch: jest.fn().mockResolvedValue(""),
+    pull: jest.fn().mockResolvedValue(""),
+    push: jest.fn().mockResolvedValue(""),
+    remote: jest.fn().mockResolvedValue(""),
+  }));
+});
+
 jest.mock("../workspace", () => ({
   WorkspaceService: jest.fn().mockImplementation(() => ({
-    getRootDir: jest.fn().mockResolvedValue("/monorepo/root"),
+    getRootDir: jest.fn().mockReturnValue("/monorepo/root"),
     readPackageJson: jest.fn().mockResolvedValue({
       repository: "https://github.com/deeeed/universe",
     }),

--- a/src/core/__tests__/changelog-keep-a-changelog.test.ts
+++ b/src/core/__tests__/changelog-keep-a-changelog.test.ts
@@ -16,13 +16,17 @@ jest.mock("fs", () => ({
     access: jest.fn(),
     stat: jest.fn(),
   },
+  statSync: jest.fn().mockReturnValue({
+    isFile: () => true,
+    isDirectory: () => true,
+  }),
 }));
 
 jest.mock("conventional-changelog", () => jest.fn());
 
 // Create a proper mock instance
 const mockWorkspaceService = {
-  getRootDir: jest.fn().mockResolvedValue("/monorepo/root"),
+  getRootDir: jest.fn().mockReturnValue("/monorepo/root"),
   readPackageJson: jest.fn().mockResolvedValue({
     name: "@siteed/publisher",
     repository: {
@@ -39,6 +43,26 @@ const mockWorkspaceService = {
 jest.mock("../workspace", () => ({
   WorkspaceService: jest.fn(() => mockWorkspaceService),
 }));
+
+jest.mock("simple-git", () => {
+  return jest.fn().mockImplementation(() => ({
+    init: jest.fn(),
+    addConfig: jest.fn(),
+    checkIsRepo: jest.fn().mockResolvedValue(true),
+    status: jest.fn().mockResolvedValue({ current: "main" }),
+    branch: jest.fn().mockResolvedValue({ current: "main" }),
+    raw: jest.fn().mockResolvedValue(""),
+    log: jest.fn().mockResolvedValue({ all: [] }),
+    tags: jest.fn().mockResolvedValue({ all: [] }),
+    revparse: jest.fn().mockResolvedValue(""),
+    show: jest.fn().mockResolvedValue(""),
+    diff: jest.fn().mockResolvedValue(""),
+    fetch: jest.fn().mockResolvedValue(""),
+    pull: jest.fn().mockResolvedValue(""),
+    push: jest.fn().mockResolvedValue(""),
+    remote: jest.fn().mockResolvedValue(""),
+  }));
+});
 
 describe("KeepAChangelogService", () => {
   let service: ChangelogService;

--- a/src/core/__tests__/changelog-version.test.ts
+++ b/src/core/__tests__/changelog-version.test.ts
@@ -14,14 +14,32 @@ jest.mock("fs", () => ({
     access: jest.fn(),
     stat: jest.fn(),
   },
+  statSync: jest.fn(),
 }));
+
+jest.mock("simple-git", () => {
+  return jest.fn().mockImplementation(() => ({
+    init: jest.fn(),
+    addConfig: jest.fn(),
+    checkIsRepo: jest.fn().mockResolvedValue(true),
+    status: jest.fn().mockResolvedValue({ current: "main" }),
+    branch: jest.fn().mockResolvedValue({ current: "main" }),
+  }));
+});
 
 jest.mock("../workspace", () => ({
   WorkspaceService: jest.fn().mockImplementation(() => ({
-    getRootDir: jest.fn().mockResolvedValue("/monorepo/root"),
+    getRootDir: jest.fn().mockReturnValue("/monorepo/root"),
     readPackageJson: jest.fn().mockResolvedValue({
-      repository: "https://github.com/deeeed/universe",
+      name: "@siteed/publisher",
+      repository: {
+        type: "git",
+        url: "https://github.com/deeeed/universe",
+      },
     }),
+    getPackageJsonPath: jest
+      .fn()
+      .mockResolvedValue("/monorepo/root/package.json"),
   })),
 }));
 
@@ -46,7 +64,7 @@ describe("ChangelogService - Version Management", () => {
         tag: true,
         remote: "origin",
       },
-      workspaceService.getRootDir(),
+      ROOT_DIR,
     );
     service = new ChangelogService(logger, workspaceService, git);
     jest.clearAllMocks();

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -24,7 +24,7 @@ export class Logger {
     this.level = options.level ?? this.getLogLevelFromEnv() ?? LogLevel.INFO;
 
     // Special case for debug flag - can be enabled via options or env
-    if (options.debug || process.env.DEBUG) {
+    if (options.debug ?? process.env.DEBUG) {
       this.level = LogLevel.DEBUG;
     }
   }

--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -235,4 +235,17 @@ export class Prompts {
 
     return confirmed;
   }
+
+  async confirmAutoGeneration(): Promise<boolean> {
+    const { confirmed } = await inquirer.prompt<{ confirmed: boolean }>([
+      {
+        type: "confirm",
+        name: "confirmed",
+        message:
+          "Would you like to automatically generate changelog entries from commits?",
+        default: true,
+      },
+    ]);
+    return confirmed;
+  }
 }


### PR DESCRIPTION
# Description
This PR improves the changelog generation process by adding enhanced logging capabilities, better git integration, and smarter handling of monorepo/single repo environments. The changes make the tool more robust and user-friendly while providing better visibility into the generation process.

## Key Changes

### 🔍 Debug Mode & Logging Enhancements
- Added `--debug` CLI flag for detailed logging
- Improved logging for root directory detection and git changes
- Enhanced error handling and debug messages throughout the codebase

### 📝 Changelog Generation Improvements
- Added support for automatic changelog entry generation from git commits
- Improved commit message formatting with repository URL integration
- Enhanced unreleased changes detection and handling
- Added interactive prompts for changelog generation method selection

### 🏗️ Workspace Management
- Improved monorepo root directory detection
- Added fallback to single repo mode when no workspaces are defined
- Enhanced package path resolution for both monorepo and single repo setups
- Fixed root package.json handling in single repo environments

### 🧪 Testing Improvements
- Updated test mocks for git operations
- Enhanced test coverage for workspace detection
- Added new test cases for changelog generation
- Improved mock implementations for filesystem operations

## Implementation Details

- The `publisher` CLI now supports a `--debug` flag that enables detailed logging
- Root directory detection now gracefully handles both monorepo and single repo setups
- Git commit information is now displayed with commit hashes and URLs in changelog entries
- Added new interactive prompts for choosing between automatic and manual changelog generation
- Improved workspace glob pattern handling for better package detection

## Testing Instructions

1. Test debug mode:
   ```bash
   ./publisher --debug
   ```

2. Test changelog generation:
   ```bash
   ./publisher changelog
   ```

3. Verify both monorepo and single repo scenarios:
   - Run in a monorepo with multiple packages
   - Run in a single package repository
